### PR TITLE
SSH 远程会话数据源：SSH 远程对话自动改查远端机数据库

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ Click ⚙ to toggle any bar item, override the context window size, or switch th
 
 - **Automatic context-window detection**: native ZCode UI → model catalog → `config.json` fallback.
 - **Session tracking**: each window shows only the data of its own focused session — zero cross-window bleed.
+- **SSH remote sessions (v9)**: when the desktop client is connected to a remote zcode-server, session data lives in the remote machine's `~/.zcode/cli/db/db.sqlite`. Add a `remote` section to `config.json` and the bar **automatically switches to querying the remote host over SSH** when a remote conversation is focused — a ☁ "remote" badge appears (hover for host name / last error), and both session stats and the "today" total come from the remote database. The remote host only needs the same `zusage.py` deployed (its own config must NOT enable `remote`, to avoid recursion). Requires passwordless SSH (public-key auth) to the server; the pump polls at `remote.poll_ms` (default 3000) while a remote session is focused — local sessions remain purely event-driven.
+
+  ```json
+  "remote": {
+    "enabled": true,
+    "ssh": "ssh user@server",
+    "script": "~/.zcode/zcode-token-usage-statusbar/zusage.py",
+    "python": "python3",
+    "timeout_s": 6,
+    "poll_ms": 3000,
+    "host_label": "my-server"
+  }
+  ```
 - **MCP in-chat query**: `token_usage(scope)` supporting current / today / week / days:N / sessions:N / models:days / session:<id prefix>.
 - **CLI**: `python zusage.py [now|today|json|days N|sessions [N]|models [days]|watch]`.
 - **/usage command** in the chat input.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,6 +70,21 @@ ZCode 的插件机制（`plugin.json`）只能提供 MCP / skills / commands / h
 
 - **上下文窗口自动识别**：优先读 ZCode 原生 UI（输入框工具行按钮文本"…总量 N"，服务端下发、自动跟随模型）→ 模型目录查表 → `config.json` 兜底。
 - **会话跟随**：泵按窗口注入本窗口焦点会话 id（渲染端经客户端 IPC 通道上报），每个对话窗口只显示它自己的数据，池里没有就显示零值、绝不串显别的会话。
+- **SSH 远程会话支持（v9）**：桌面客户端连远端 zcode-server 时，会话数据落在远端机的 `~/.zcode/cli/db/db.sqlite`，本地库查不到。配置 `config.json` 的 `remote` 段后，切换到远端对话会**自动改为 SSH 到远端机查询**：条面出现 ☁「远端」徽标（悬停显示主机名与最近错误），会话数据与「今日合计」均为远端值。远端机只需部署同一份 `zusage.py`（保持其 config 不含 remote 段即可，防递归）：
+
+  ```json
+  "remote": {
+    "enabled": true,
+    "ssh": "ssh 用户名@服务器地址",
+    "script": "~/.zcode/zcode-token-usage-statusbar/zusage.py",
+    "python": "python3",
+    "timeout_s": 6,
+    "poll_ms": 3000,
+    "host_label": "我的服务器"
+  }
+  ```
+
+  前提：本地到服务器的 `ssh` 免密可用（公钥认证）。实现上，本地 `zusage.py` 对本地库查不到的会话 id（双重白名单校验）执行 `ssh <host> python3 <script> json <sids>`，把远端快照合并进 payload；远端返回 `known_sids` 供负缓存（确认无此会话 2 分钟内不重问，ssh 失败 60 秒退避），本地新会话（session 表已有行）不会触发远端查询。泵在远端会话聚焦期间按 `poll_ms` 轮询（本地会话仍是纯事件触发、零轮询）；`poll_ms` 别低于 1000，跨公网建议配合 ssh ControlMaster 连接复用。
 - **MCP 对话内查询**：`token_usage(scope)` 工具，scope 支持 current / today / week / days:N / sessions:N / models:days / session:<id前缀>。
 - **CLI**：`python zusage.py [now|today|json|days N|sessions [N]|models [days]|watch [秒]]`。
 - **/usage 命令**：对话输入框触发 MCP 查询。

--- a/config.example.json
+++ b/config.example.json
@@ -4,5 +4,14 @@
   "heartbeat_ms": 30000,
   "hot_reload": true,
   "context_window": 1000000,
-  "lang": "zh"
+  "lang": "zh",
+  "remote": {
+    "enabled": false,
+    "ssh": "ssh 用户名@服务器地址",
+    "script": "~/.zcode/zcode-token-usage-statusbar/zusage.py",
+    "python": "python3",
+    "timeout_s": 6,
+    "poll_ms": 3000,
+    "host_label": "我的服务器"
+  }
 }

--- a/inject-main.cjs
+++ b/inject-main.cjs
@@ -122,6 +122,16 @@ function dbStamp() {
   return m;
 }
 
+/* v9 远程数据源：payload.recent 里带 remote 标记的会话 = zusage.py 经 SSH 从远端机取得。
+ * 本地 fs.watch 对远端库写入无感，聚焦远端会话期间由泵按 remote.poll_ms 主动轮询
+ * （默认 3s），切回本地会话即恢复纯事件触发、零进程零轮询。 */
+const remoteSids = new Set();
+let lastHadRemote = false;
+function remotePollMs() {
+  const r = readCfgCached().remote;
+  return Math.max(1000, (r && r.poll_ms | 0) || 3000);
+}
+
 let busy = false;
 let pushCount = 0;
 let lastSpawn = 0;    // 上次发起查询时刻（activity_min_ms 限频用）
@@ -130,6 +140,8 @@ let lastWants = "";   // 上次查询用的会话 id 集合（变化即拉，防
 
 function handlePayload(payload) {
   if (!payload || typeof payload !== "object") return;
+  remoteSids.clear();
+  for (const r of (payload.recent || [])) if (r && r.remote && r.sid) remoteSids.add(r.sid);
   for (const wc of webContents.getAllWebContents()) pushOnce(wc, payload);
   // 定位诊断：每 ~15 次拉取收集每个窗口各自的 __zusageDiag，附加泵侧证据后写 diag-<n>.json（多窗口互不覆盖）
   if (++pushCount % 15 === 1) {
@@ -217,6 +229,7 @@ function runQuery(wants) {
   const done = (payload) => {
     busy = false;
     if (payload) handlePayload(payload);
+    if (lastHadRemote) scheduleRetry(remotePollMs());   // 远端会话聚焦期间维持轮询链
     // 失败不原地重试：下一笔 db 写入/心跳会再拉，最多滞后一个心跳
   };
   if (readCfgCached().resident !== false && pyFail < 3) {
@@ -252,6 +265,7 @@ function legacySpawn(wants) {
   py.on("close", () => {
     clearTimeout(killTimer);
     busy = false;
+    if (lastHadRemote) scheduleRetry(remotePollMs());
     if (out.trim()) {
       let payload;
       try { payload = JSON.parse(out); } catch (e) { payload = null; }
@@ -292,10 +306,14 @@ function maybeSpawn() {
         if (sid && !wants.includes(sid)) wants.push(sid);
       });
       const key = wants.join(",");
-      if (key === lastWants && st && st === lastStamp) return;   // 会话与数据都没变：零进程
+      /* v9：聚焦 SSH 远程会话时本地 db 不写入（st 恒定），短路径放行、改按 remote 轮询间隔 */
+      const remoteActive = wants.some((s) => remoteSids.has(s));
+      if (key === lastWants && st && st === lastStamp && !remoteActive) return;   // 会话与数据都没变：零进程
       const now = Date.now();
-      if (now - lastSpawn < wait) { scheduleRetry(wait - (now - lastSpawn) + 50); return; }
+      const effWait = remoteActive ? remotePollMs() : wait;
+      if (now - lastSpawn < effWait) { scheduleRetry(effWait - (now - lastSpawn) + 50); return; }
       lastWants = key;
+      lastHadRemote = remoteActive;
       if (st) lastStamp = st;
       lastSpawn = now;
       runQuery(key);
@@ -364,4 +382,4 @@ const hook = (wc) => {
 app.on("web-contents-created", (e, wc) => hook(wc));
 for (const wc of webContents.getAllWebContents()) hook(wc);
 
-LOG("injected v8, resident query mode (per-window active session via IPC, fs.watch db dir, zusage serve + one-shot fallback, activity_min_ms/heartbeat_ms, query timeout 15s)");
+LOG("injected v9, resident query mode + remote SSH datasource (per-window active session via IPC, fs.watch db dir, remote poll_ms while remote session focused, zusage serve + one-shot fallback, activity_min_ms/heartbeat_ms, query timeout 15s)");

--- a/overlay.js
+++ b/overlay.js
@@ -387,6 +387,13 @@
       var tls = d.tools || { total: 0, errors: 0, list: [] };
       var items = [], tips = [];
       function it(inner, tip, cls) { items.push('<span class="it' + (cls ? " " + cls : "") + '">' + inner + "</span>"); tips.push(tip || null); }
+      if (d.remote) {   // v9：SSH 远程会话（数据取自远端机），置顶徽标标明数据源
+        it(ico('<path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/>') +
+          '<span class="dim">' + L("远端", "remote") + "</span>",
+          L("数据源：SSH 远程服务器 ", "Data source: remote server over SSH ") + (d.remote_host || "?") + "\n" +
+          L("会话数据实时取自远端机的 ZCode 数据库，「今日合计」亦为远端值", "Session data is fetched live from the remote machine's ZCode database; today's total is the remote value") +
+          (d.remote_error ? "\n⚠ " + L("最近一次远端查询失败：", "Last remote query failed: ") + d.remote_error : ""));
+      }
       if (last.tps) {   // 最近一次请求的生成速度，置顶显示；随数值三档变色
         var tpsCls = last.tps >= 70 ? "ok" : last.tps >= 40 ? "warm" : "hot";
         it(ico('<path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z"/>') +
@@ -572,8 +579,11 @@
       state.excActive = excActive(p);   // 气泡的显示依据（track 每帧消费）
       var view = {
         session: p, last_turn: p.last_turn || {}, last: p.last || {},
-        today: d.today, context_window: p.context_window, context_auto: p.context_auto,
+        /* v9：远端会话的「今日合计」用远端机数据，本地 today 只在显示本地会话时使用 */
+        today: (p.remote && d.remote_today) ? d.remote_today : d.today,
+        context_window: p.context_window, context_auto: p.context_auto,
         code: p.code, ctx_exc: p.ctx_exc, tools: p.tools,
+        remote: !!p.remote, remote_host: p.remote_host || "", remote_error: d.remote_error || "",
         sub: p.sub || {requests: 0, total: 0, input: 0, output: 0, cache_read: 0, active: false, list: []},
       };
       state.lastSub = view.sub;   // 子代理明细面板的数据源（开关面板/数据推送刷新用）

--- a/zusage.py
+++ b/zusage.py
@@ -6,7 +6,9 @@
 """
 import json
 import re
+import shlex
 import sqlite3
+import subprocess
 import sys
 import time
 from datetime import datetime, timedelta
@@ -552,6 +554,121 @@ _EMPTY_TURN = {"requests": 0, "retries": 0, "tool_calls": 0, "tool_errors": 0, "
                "total": 0, "duration_ms": 0, "ttft_ms": 0}
 
 
+# ---------- 远端数据源（SSH，v9）----------
+# SSH 远程场景：桌面客户端连的是远端 zcode-server，会话数据落在远端机的
+# ~/.zcode/cli/db/db.sqlite，本地库里查不到。config.json 配了 remote 时，
+# force 会话中本地无数据的 sid 改为 SSH 到远端执行同一份 zusage.py json，
+# 把远端快照（结构同源）打上 remote 标记合并进本 payload；today 同理带回远端值。
+# 服务器侧只需部署同一份 zusage.py（无需 config 的 remote 段，保持关闭防递归）。
+
+_REMOTE_NEG_TTL_OK = 2 * 60 * 1000      # 远端确认"无此会话"后多久内不再问（远端新会话极少数竞态下最迟 2 分钟自愈）
+_REMOTE_NEG_TTL_ERR = 60 * 1000         # ssh 失败/超时：短退避，尽快自愈
+_REMOTE_NEG = {}                        # sid -> [查询时刻ms, 生效TTLms]
+
+
+def _remote_cfg(cfg):
+    """config.json 的 remote 段 → 归一化配置或 None。字段：
+    enabled(true) / ssh("ssh 主机别名" 或 argv 数组) / script(远端 zusage.py 路径) /
+    python(远端解释器) / timeout_s(ssh 超时) / host_label(徽标显示名)。"""
+    r = cfg.get("remote")
+    if not isinstance(r, dict) or not r.get("enabled"):
+        return None
+    ssh = r.get("ssh") or ""
+    if isinstance(ssh, list):
+        ssh_argv = [str(x) for x in ssh]
+    else:
+        try:
+            ssh_argv = shlex.split(str(ssh))
+        except ValueError:
+            ssh_argv = str(ssh).split()
+    if not ssh_argv:
+        return None
+    return {
+        "ssh_argv": ssh_argv,
+        "script": str(r.get("script") or ".zcode/zcode-token-usage-statusbar/zusage.py"),
+        "python": str(r.get("python") or "python3"),
+        "timeout_s": min(14.0, max(1.0, float(r.get("timeout_s") or 6))),
+        "host_label": str(r.get("host_label") or (ssh_argv[-1] if len(ssh_argv) > 1 else "remote")),
+    }
+
+
+def _remote_exec(sids, rcfg):
+    """SSH 执行远端 zusage.py json <sids>。返回 (by_sid, remote_today, err)。
+    sid 在进入该函数前已过 [A-Za-z0-9_-]+ 白名单（snapshot 与泵双重校验），
+    ssh 远端命令按 shell 拼接，此处不再引入任何可注入内容。"""
+    cmd = rcfg["ssh_argv"] + [rcfg["python"], rcfg["script"], "json", ",".join(sids)]
+    err = None
+    payload = None
+    try:
+        p = subprocess.run(cmd, capture_output=True, timeout=rcfg["timeout_s"])
+        out = p.stdout.decode("utf-8", "replace")
+        if p.returncode != 0:
+            err = f"ssh rc={p.returncode}: {p.stderr.decode('utf-8', 'replace').strip()[:160]}"
+        else:
+            # 取最后一行能解析的 JSON 对象：容忍远端登录 banner 混进 stdout
+            for line in reversed(out.splitlines()):
+                line = line.strip()
+                if line.startswith("{"):
+                    try:
+                        payload = json.loads(line)
+                        break
+                    except ValueError:
+                        continue
+            if payload is None:
+                err = "remote returned no JSON payload"
+    except subprocess.TimeoutExpired:
+        err = f"ssh timeout after {rcfg['timeout_s']:g}s"
+    except OSError as e:
+        err = f"ssh spawn failed: {e}"
+    if payload is None:
+        return {}, None, err or "remote query failed"
+    # known_sids = 远端库里真实存在的 force 会话（session 行或任一 usage 行）。
+    # 远端对未知 sid 也会产出零值快照，不按它过滤的话"确无此会话"永远判不了，
+    # 负缓存失效 → 本地新会话每轮都白跑一次 ssh。缺 known_sids 字段 = 远端是旧版
+    # 脚本：退化为按活跃度识别（零值快照 requests/last_at 恒为 0）。
+    known = payload.get("known_sids")
+    legacy = not isinstance(known, list)
+    known = set(known or [])
+    by = {}
+    for rec in payload.get("recent") or []:
+        if not isinstance(rec, dict) or rec.get("sid") not in sids:
+            continue
+        # 远端旧版脚本（无 known_sids）退化为按活跃度识别：零值快照 requests/last_at 恒为 0
+        found = (rec["sid"] in known) if not legacy else (
+            (rec.get("requests") or 0) > 0 or (rec.get("last_at") or 0) > 0)
+        if found:
+            rec["remote"] = True
+            rec["remote_host"] = rcfg["host_label"]
+            by[rec["sid"]] = rec
+    return by, payload.get("today"), err
+
+
+def _remote_fetch(force_sids, have_local, rcfg):
+    """本地库不存在的 force 会话 → 远端补齐。带负缓存：远端确认无此会话按 TTL 免问；
+    ssh 失败用短 TTL 快速自愈。have_local = 本地 session/usage 表真实存在的 sid 集合
+    （本地新会话即便还没有请求也不会去远端白跑）。"""
+    now_ms = int(time.time() * 1000)
+    missing = []
+    for s in force_sids:
+        if s in have_local:
+            continue
+        ent = _REMOTE_NEG.get(s)
+        if ent and now_ms - ent[0] < ent[1]:
+            continue
+        missing.append(s)
+    if not missing:
+        return {}, None, None
+    by, today, err = _remote_exec(missing, rcfg)
+    if len(_REMOTE_NEG) > 256:
+        _REMOTE_NEG.clear()   # 防长驻膨胀，正常会话数到不了
+    for s in missing:
+        if s in by:
+            _REMOTE_NEG.pop(s, None)
+        else:
+            _REMOTE_NEG[s] = (now_ms, _REMOTE_NEG_TTL_ERR if err else _REMOTE_NEG_TTL_OK)
+    return by, today, err
+
+
 def snapshot(force_sid=""):
     """单次快照：最新会话 + 最近 6+6 会话池 + 今日。
     force_sid：各窗口当前会话 id，逗号分隔（泵按窗口汇总上报：主进程 IPC 映射的焦点会话 +
@@ -568,6 +685,23 @@ def snapshot(force_sid=""):
         today = _cached_agg("today", lambda: range_usage(
             con, _epoch_ms(_day_start()), _epoch_ms(_day_start() + timedelta(days=1))))
         rows = _scan_session_ids(con)
+        # v9：force 会话在本库的真实存在性（session 行或任一 usage 行）。远端数据源
+        # 双向依赖它：本地已存在 → 不去远端白跑；远端按同款判定区分"确无此会话"与
+        # "零值快照"（负缓存的依据）。两次索引点查 <1ms。
+        known_sids = []
+        if force_sids:
+            qmarks = ",".join("?" * len(force_sids))
+            have_local = {r[0] for r in con.execute(
+                f"select id from session where id in ({qmarks})", force_sids)}
+            have_local |= {r[0] for r in con.execute(
+                f"select distinct session_id from model_usage where session_id in ({qmarks})",
+                force_sids)}
+            known_sids = [s for s in force_sids if s in have_local]
+        # 远端补齐（v9）：本地不存在的 force 会话（SSH 远程会话）改查远端库
+        rcfg = _remote_cfg(cfg)
+        remote_by, remote_today, remote_err = {}, None, None
+        if rcfg and force_sids:
+            remote_by, remote_today, remote_err = _remote_fetch(force_sids, have_local, rcfg)
         latest_sid = max(rows, key=lambda r: r[1])[0] if rows else None
         if latest_sid:
             base = _session_snapshot(con, latest_sid, cfg)
@@ -593,8 +727,10 @@ def snapshot(force_sid=""):
         ids = [x for x in ids if not (x in seen or seen.add(x))]
         if latest_sid and latest_sid not in ids:
             ids.insert(0, latest_sid)
+        # 远端命中的会话不进本地 ids 循环（本地 _session_snapshot 查不到只会产出零值行）
+        remote_ids = [s for s in force_sids if s in remote_by]
         for fs in reversed(force_sids):
-            if fs not in ids:
+            if fs not in ids and fs not in remote_ids:
                 ids.insert(0, fs)
         # recent 池瘦身（v8）：状态条只渲染 1 个会话，完整快照只给兜底候选
         # （force + latest + 最近活跃前 2），其余长尾行走轻量查询（单会话 38ms→2ms）。
@@ -607,6 +743,8 @@ def snapshot(force_sid=""):
                 rec.append(_session_snapshot(con, sid, cfg))
             else:
                 rec.append(_light_snapshot(con, sid, cfg))
+        # rec 建好后把远端快照挂到池首：overlay 按 sid 匹配 mine，顺序只影响兜底展示
+        rec = [remote_by[s] for s in reversed(remote_ids)] + rec
         return {
             "session": base,
             "last_turn": base["last_turn"],
@@ -616,6 +754,10 @@ def snapshot(force_sid=""):
                 "cache_read": today[3], "total": today[4],
                 "reasoning": today[6], "retries": today[7], "cache_write": today[8],
             },
+            # 远端数据源（v9）：显示远端会话时 overlay 用 remote_today 替代本地 today
+            "remote_today": remote_today,
+            "remote_error": remote_err,
+            "known_sids": known_sids,
             "context_window": base["context_window"],
             "context_auto": base["context_auto"],
             "code": base["code"],


### PR DESCRIPTION
## 背景

桌面客户端经 SSH 连远端 zcode-server 时，会话与用量数据落在**远端机**的 `~/.zcode/cli/db/db.sqlite`，本地库查不到：状态栏只能显示零值，泵的 `fs.watch` 也感知不到远端写入。

## 方案

复用现有 `zusage.py json` 快照协议：本地查不到的 force 会话 id，经 SSH 在远端机执行**同一份** `zusage.py`，把远端快照合并进 payload（打 `remote`/`remote_host` 标记），结构同源、渲染层零新增分支。

- **zusage.py**：远端拉取合并；`known_sids` 负缓存（确认无此会话 2 分钟免问、ssh 失败 60 秒退避），本地会话零探测；远端「今日合计」经 `remote_today` 带回；sid 全程 `[A-Za-z0-9_-]+` 白名单，远端命令不含用户可控片段
- **inject-main.cjs**：远端会话聚焦期间按 `remote.poll_ms`（默认 3s）轮询，切回本地立即恢复纯事件触发（空闲零进程零轮询不变）
- **overlay.js**：☁「远端」徽标（悬停显示主机名与最近错误）；显示远端会话时「今日合计」切换为远端值

配置见 `config.example.json` 新增的 `remote` 段（README 中英已补文档）。远端机只需部署同一份 `zusage.py`，其 config 不含 remote 段即可天然防递归。

## 兼容与安全

- 不配 `remote` 段时行为与现状完全一致（已回归验证）
- 负缓存 + 本地存在性检查，不会对本地新会话、未知 sid 反复打 ssh
- `install.py` 沿用已有 config.json，重装不丢 remote 配置

## 测试

真实 sshd 鉴权回环端到端实测：远端会话合并与实时刷新、负缓存命中、本地+远端混合单次查询、ssh 失败降级（错误进徽标 tooltip）、纯本地行为不变。