### PR TITLE
修复 Windows 兜底扫描误注入同机其它 Electron 应用；新增 --root 免记完整 asar 路径

### DIFF
--- a/install.py
+++ b/install.py
@@ -10,7 +10,11 @@ asar 注入行与 MCP 注册都指向数据目录 —— 之后 clone 目录可�
 
 用法（仓库根目录）：
   python install.py               # 全量安装：复制运行时 → 注入 asar → 注册 MCP → /usage 命令 → 监控窗口
-  python install.py --asar PATH   # 指定 app.asar（自动探测失败时用；首次成功后记住，之后免传）
+  python install.py --root PATH   # 指定 ZCode 根目录（自动接上平台固定的 resources/app.asar）；
+                                  #   Windows：python install.py --root D:\Apps\ZCode
+                                  #   macOS：  python install.py --root /Applications/ZCode.app
+                                  #   首次成功后记住，之后免传
+  python install.py --asar PATH   # 指定 app.asar 完整路径（自动探测失败时用；同样记住）
   python install.py --no-mcp      # 只装状态条，不动 MCP 与 /usage 命令
   python install.py --dev         # 开发模式：不复制运行时，注入直指本仓库目录，配置/诊断留在仓库
                                   #   （作者迭代用，改仓库文件即时热更新；与标准形态重跑 install 即互切）
@@ -35,6 +39,28 @@ import sys
 from pathlib import Path
 
 HERE = Path(__file__).parent.resolve()
+
+
+def normalize_asar_arg(p, kind="asar"):
+    """把 --asar/--root 的实参归一成 app.asar 路径：三者都接受——
+      * 完整 asar 路径（尾部 app.asar，惯用写法）
+      * asar 所在目录（.../resources）
+      * ZCode 根目录（--root：win/linux 下的安装目录；macOS 下 ZCode.app）
+    Electron 布局下相对根目录的路径是固定的（Windows/Linux <root>/resources/app.asar，
+    macOS bundle <root>/Contents/Resources/app.asar），所以指向根目录就够了。"""
+    p = expand(p)
+    if p.is_file():
+        return p
+    if kind == "root":
+        cands = [p / "resources" / "app.asar"]
+        if sys.platform == "darwin":
+            cands.insert(0, p / "Contents" / "Resources" / "app.asar")
+    else:
+        cands = [p / "app.asar"]
+    for c in cands:
+        if c.is_file():
+            return c
+    return p / "app.asar" if kind == "root" else p
 
 
 def _sudo_user():
@@ -399,8 +425,10 @@ def main():
 
     ap = argparse.ArgumentParser(description=L("ZCode Token 用量状态栏 一键安装",
                                                "ZCode Token Usage Status Bar one-shot installer"))
-    ap.add_argument("--asar", help=L("app.asar 路径（默认自动探测；首次安装成功后记住，之后免传）",
-                                     "path to app.asar (auto-detected by default; remembered after the first install)"))
+    ap.add_argument("--asar", help=L("app.asar 完整路径（默认自动探测；也可传 --root 指向安装目录）",
+                                     "full path to app.asar (auto-detected by default; or use --root for the install directory)"))
+    ap.add_argument("--root", help=L("ZCode 根目录（如 D:\\Apps\\ZCode 或 ZCode.app；自动接上平台固定的 resources/app.asar）",
+                                     "ZCode root directory (e.g. D:\\Apps\\ZCode or ZCode.app; the platform-fixed resources/app.asar is appended)"))
     ap.add_argument("--no-mcp", action="store_true", help=L("跳过 MCP 注册与 /usage 命令", "skip MCP registration and the /usage command"))
     ap.add_argument("--dev", action="store_true", help=L("开发模式：不复制运行时，注入直指本仓库目录（配置/诊断留在仓库）",
                                                          "dev mode: no runtime copy; injection points at this repo (config/diagnostics stay in the repo)"))
@@ -438,16 +466,19 @@ def main():
         print(L("卸载完成。", "Uninstall complete."))
         return 0 if ok else 1
 
-    asar = Path(args.asar) if args.asar else (find_asar() or ask_asar())
+    asar = normalize_asar_arg(args.root, "root") if args.root else (
+        normalize_asar_arg(args.asar) if args.asar else (find_asar() or ask_asar()))
     if not asar or not asar.is_file():
         if sys.platform == "win32":
-            example = r"E:\Apps\ZCode\resources\app.asar"
+            example = r"--root D:\Apps\ZCode"
         elif sys.platform.startswith("linux"):
-            example = "/opt/ZCode/resources/app.asar"
+            example = "--root /opt/ZCode"
         else:
-            example = "/Applications/ZCode.app/Contents/Resources/app.asar"
-        print(L(f"找不到 app.asar。用 --asar 指定，例如：python install.py --asar {example}",
-                f"app.asar not found. Specify it with --asar, e.g.: python install.py --asar {example}"))
+            example = "--root /Applications/ZCode.app"
+        print(L(f"找不到 app.asar。用 --root 指向 ZCode 安装目录，例如：python install.py {example}",
+                f"app.asar not found. Point --root at the ZCode install directory, e.g.: python install.py {example}"))
+        print(L("（也可用 --asar 指定 app.asar 完整路径）",
+                "(or specify the full app.asar path with --asar)"))
         return 1
     print(L(f"[目标] {asar}", f"[target] {asar}"))
     if (sys.platform != "win32" and os.geteuid() != 0

--- a/install.py
+++ b/install.py
@@ -113,6 +113,40 @@ def load_lang_from_config(dev):
         return None
 
 
+def asar_package_name(asar_path):
+    """读 asar 内 package.json 的 name 字段，辅助识别"这是不是 ZCode 的 asar"；
+    读不到（非 asar / 无 package.json / 条目 unpacked 外置）返回 None。"""
+    import struct
+    try:
+        with open(asar_path, "rb") as f:
+            a, b, c, d = struct.unpack("<4I", f.read(16))
+            if a != 4:
+                return None
+            header = json.loads(f.read(d))
+        node = header.get("files", {}).get("package.json")
+        if not isinstance(node, dict) or "size" not in node:
+            return None
+        with open(asar_path, "rb") as f:
+            f.seek(8 + b + int(node["offset"]))
+            data = f.read(int(node["size"]))
+        if b"\x00" in data:   # 被 pickle 对齐补零 / 条目加密等异常，放弃识别
+            return None
+        return json.loads(data.decode("utf-8")).get("name")
+    except (OSError, ValueError, KeyError, struct.error):
+        return None
+
+
+def is_zcode_app(asar_path):
+    """该 asar 是否属于 ZCode：ZCode.exe 与 asar 同级，或包里 package.json 的 name 含 zcode。
+    兜底扫描必须过此判定——%LOCALAPPDATA%\\Programs 下可能有其它 Electron 应用
+    （如 opencode-aidesktop），按目录名猜会注入错目标：真 ZCode 永不生效。"""
+    asar_path = Path(asar_path)
+    if (asar_path.parent.parent / "ZCode.exe").is_file():
+        return True
+    name = asar_package_name(asar_path)
+    return isinstance(name, str) and "zcode" in name.lower()
+
+
 def find_asar():
     env = os.environ.get("ZCODE_ASAR")   # 非默认安装位置：设一次环境变量，永久免 --asar
     if env:
@@ -125,11 +159,12 @@ def find_asar():
             return p
     if sys.platform == "win32":
         # 兜底：扫 %LOCALAPPDATA%\Programs 一层子目录
+        # （必须过 is_zcode_app：该目录下可能有其它 Electron 应用，命中它们会注入错目标）
         prog = expand(r"%LOCALAPPDATA%\Programs")
         if prog.is_dir():
             for ch in prog.iterdir():
                 p = ch / "resources" / "app.asar"
-                if p.is_file():
+                if p.is_file() and is_zcode_app(p):
                     return p
     elif sys.platform.startswith("linux"):
         # 兜底：扫 /opt、/usr/lib、/usr/local/lib 一层子目录，目录名含 zcode 即命中

--- a/patch_install.py
+++ b/patch_install.py
@@ -108,13 +108,48 @@ def set_runtime(path):
     INJECT_LINE = INJECT_LINE_TMPL.format(url=LOADER.as_uri())
 
 
+def asar_package_name(asar_path):
+    """读 asar 内 package.json 的 name 字段，辅助识别"这是不是 ZCode 的 asar"；
+    读不到（非 asar / 无 package.json / 条目 unpacked 外置）返回 None。"""
+    try:
+        with open(asar_path, "rb") as f:
+            a, b, c, d = struct.unpack("<4I", f.read(16))
+            if a != 4:
+                return None
+            header = json.loads(f.read(d))
+        node = header.get("files", {}).get("package.json")
+        if not isinstance(node, dict) or "size" not in node:
+            return None
+        with open(asar_path, "rb") as f:
+            f.seek(8 + b + int(node["offset"]))
+            data = f.read(int(node["size"]))
+        if b"\x00" in data:   # 被 pickle 对齐补零 / 条目加密等异常，放弃识别
+            return None
+        return json.loads(data.decode("utf-8")).get("name")
+    except (OSError, ValueError, KeyError, struct.error):
+        return None
+
+
+def is_zcode_app(asar_path):
+    """该 asar 是否属于 ZCode：可执行文件在 <root>/ZCode.exe，或包里 name 含 zcode。
+    用于兜底扫描时排除同机其它 Electron 应用——%LOCALAPPDATA%\\Programs 下可能有
+    opencode 等应用，命中它们会注入错目标且真 ZCode 永不生效。"""
+    asar_path = Path(asar_path)
+    if zcode_exe_for(asar_path) is not None:
+        return True
+    name = asar_package_name(asar_path)
+    return isinstance(name, str) and "zcode" in name.lower()
+
+
 def zcode_exe_for(asar_path):
-    """从 asar 位置推 ZCode 可执行文件（仅语法自检用）：Windows 布局 <root>/ZCode.exe，
+    """从 asar 位置推 ZCode 可执行文件（语法自检用）：Windows 布局 <root>/ZCode.exe，
     macOS bundle 布局 <root>/MacOS/ZCode，Linux 布局 <root>/zcode（deb/rpm 官方包，/opt/ZCode）；
-    其它平台返回 None（语法检查自动跳过）。"""
+    非 ZCode 布局（如 %LOCALAPPDATA%\\Programs 下其它 Electron 应用）返回 None——
+    客户端进程名随之失去语义（客户端是别的应用），语法检查自动跳过。"""
     root = asar_path.parent.parent
     if IS_WIN:
-        return root / "ZCode.exe"
+        exe = root / "ZCode.exe"
+        return exe if exe.is_file() else None
     if IS_MAC:
         return root / "MacOS" / "ZCode"
     if sys.platform.startswith("linux"):


### PR DESCRIPTION
## 背景

ZCode 装在非默认目录（Windows 实测 `D:\Apps\ZCode`）时，`install.py` 自动探测落空后走 win32 兜底扫描：`%LOCALAPPDATA%\Programs` 下任何存在 `resources\app.asar` 的子目录都直接命中，不校验应用身份。同机装有其它 Electron 应用时会命中错目标，本次实测命中 `@opencode-aidesktop` `(\AppData\Local\Programs\@opencode-aidesktop)`。

后果：注入行写进 opencode 的 asar，真 ZCode 的 asar 完全没动 —— 状态栏不出现、`install_monitor.py` 永远报"未检测到注入加载"。数据侧（MCP 注册、`/usage` 命令）不受影响，所以现象很具迷惑性。Linux 兜底扫描有"目录名含 zcode"的过滤，Windows 分支没有。

## 改动

**1. win32 兜底扫描校验目标身份（提交 `a9359d8`）**

- `install.py` 新增 `asar_package_name()`（读 asar 内 `package.json` 的 name）与 `is_zcode_app()`（`ZCode.exe` 与 asar 同级，或 name 含 `zcode`），兜底扫描命中后必须过该判定
- `patch_install.py` 的 `zcode_exe_for` Windows 分支补存在性校验：`ZCode.exe` 缺失时返回 `None`（语法自检自动跳过）。原来会拿一个不存在的路径去跑 `--check`，因为下游 `is_file()` 判断实际也只是静默跳过，这次让语义显式化；macOS/Linux 分支不受影响
- 判定用"可执行文件 + 包名"双条件：只看包名的话，将来 ZCode 改包名会误伤；只看目录名则是现成 bug

**2. `--root` 直接指定根目录（提交 `2160dbd`）**

非默认位置用户此前必须输入完整路径如 `D:\Apps\ZCode\resources\app.asar`，而 `resources` 是 Electron 固定布局，用户不该记它：
```
python install.py --root D:\Apps\ZCode # Windows   
python install.py --root /Applications/ZCode.app # macOS，不必知道 bundle 内部布局
```

- 新增 `normalize_asar_arg()`：`--root` 自动接上平台固定相对路径（win/linux `<root>/resources/app.asar`，macOS `<root>/Contents/Resources/app.asar`）
- `--asar` 同步放宽为也接受 asar 所在目录；旧的完整路径写法逐字节兼容
- auto-detect 失败的提示改给 `--root` 示例

## 实测（Windows 10 19045，ZCode 装在 D:\Apps\ZCode）
```
真 ZCode  asar:  package name = @zcode/desktop,  ZCode.exe 同级   -> is_zcode_app = True
opencode  asar:  package name = @opencode-ai/desktop, 无 ZCode.exe -> is_zcode_app = False
find_asar()（ZCode 在非默认位置）                                  -> None（不再误选）
--root / --asar(目录) / --asar(完整路径) 四种写法                  -> 归一化到同一目标
```

修复后按 --root 安装，注入打进真 ZCode 的 asar，重启后状态栏正常显示、diag 正常回写。

## 影响面
- 只动 Windows 分支（新增代码都在 sys.platform == "win32" 路径上或只被其调用）；macOS/Linux 的探测与注入逻辑零行为变化
- 不传 --root 时旧命令行为不变

fix #6